### PR TITLE
Esp32 touchpad, ADC, DAC

### DIFF
--- a/esp32/Makefile
+++ b/esp32/Makefile
@@ -120,6 +120,7 @@ SRC_C = \
 	moduos.c \
 	machine_pin.c \
 	machine_touchpad.c \
+	machine_adc.c \
 	modmachine.c \
 	modnetwork.c \
 	modsocket.c \

--- a/esp32/Makefile
+++ b/esp32/Makefile
@@ -119,6 +119,7 @@ SRC_C = \
 	modutime.c \
 	moduos.c \
 	machine_pin.c \
+	machine_touchpad.c \
 	modmachine.c \
 	modnetwork.c \
 	modsocket.c \

--- a/esp32/Makefile
+++ b/esp32/Makefile
@@ -121,6 +121,7 @@ SRC_C = \
 	machine_pin.c \
 	machine_touchpad.c \
 	machine_adc.c \
+	machine_dac.c \
 	modmachine.c \
 	modnetwork.c \
 	modsocket.c \

--- a/esp32/machine_adc.c
+++ b/esp32/machine_adc.c
@@ -56,10 +56,16 @@ STATIC const madc_obj_t madc_obj[] = {
 STATIC mp_obj_t madc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw,
         const mp_obj_t *args) {
 
+    static int initialized = 0;
+    if (!initialized) {
+        adc1_config_width(ADC_WIDTH_12Bit);
+        initialized = 1;
+    }
+
     mp_arg_check_num(n_args, n_kw, 1, 1, true);
     gpio_num_t pin_id = machine_pin_get_id(args[0]);
     const madc_obj_t *self = NULL;
-    for (int i=0; i<MP_ARRAY_SIZE(madc_obj); i++) {
+    for (int i = 0; i < MP_ARRAY_SIZE(madc_obj); i++) {
         if (pin_id == madc_obj[i].gpio_id) { self = &madc_obj[i]; break; }
     }
     if (!self) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "invalid Pin for ADC"));
@@ -90,30 +96,29 @@ STATIC mp_obj_t madc_atten(mp_obj_t self_in, mp_obj_t atten_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(madc_atten_obj, madc_atten);
 
-STATIC mp_obj_t madc_width(mp_obj_t self_in, mp_obj_t width_in) {
-    // XXX This should be a classmethod, as there's only one width
-    // across all ADC channels.
+STATIC mp_obj_t madc_width(mp_obj_t cls_in, mp_obj_t width_in) {
     adc_bits_width_t width = mp_obj_get_int(width_in);
     esp_err_t err = adc1_config_width(width);
     if (err == ESP_OK) return mp_const_none;
     mp_raise_ValueError("Parameter Error");
 }
-MP_DEFINE_CONST_FUN_OBJ_2(madc_width_obj, madc_width);
+MP_DEFINE_CONST_FUN_OBJ_2(madc_width_fun_obj, madc_width);
+MP_DEFINE_CONST_CLASSMETHOD_OBJ(madc_width_obj, MP_ROM_PTR(&madc_width_fun_obj));
 
 STATIC const mp_rom_map_elem_t madc_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&madc_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_atten), MP_ROM_PTR(&madc_atten_obj) },
     { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&madc_width_obj) },
 
-    { MP_ROM_QSTR(MP_QSTR_ATTN_0db), MP_ROM_INT(ADC_ATTEN_0db) },
-    { MP_ROM_QSTR(MP_QSTR_ATTN_2_5db), MP_ROM_INT(ADC_ATTEN_2_5db) },
-    { MP_ROM_QSTR(MP_QSTR_ATTN_6db), MP_ROM_INT(ADC_ATTEN_6db) },
-    { MP_ROM_QSTR(MP_QSTR_ATTN_11db), MP_ROM_INT(ADC_ATTEN_11db) },
+    { MP_ROM_QSTR(MP_QSTR_ATTN_0DB), MP_ROM_INT(ADC_ATTEN_0db) },
+    { MP_ROM_QSTR(MP_QSTR_ATTN_2_5DB), MP_ROM_INT(ADC_ATTEN_2_5db) },
+    { MP_ROM_QSTR(MP_QSTR_ATTN_6DB), MP_ROM_INT(ADC_ATTEN_6db) },
+    { MP_ROM_QSTR(MP_QSTR_ATTN_11DB), MP_ROM_INT(ADC_ATTEN_11db) },
 
-    { MP_ROM_QSTR(MP_QSTR_WIDTH_9Bit), MP_ROM_INT(ADC_WIDTH_9Bit) },
-    { MP_ROM_QSTR(MP_QSTR_WIDTH_10Bit), MP_ROM_INT(ADC_WIDTH_10Bit) },
-    { MP_ROM_QSTR(MP_QSTR_WIDTH_11Bit), MP_ROM_INT(ADC_WIDTH_11Bit) },
-    { MP_ROM_QSTR(MP_QSTR_WIDTH_12Bit), MP_ROM_INT(ADC_WIDTH_12Bit) },
+    { MP_ROM_QSTR(MP_QSTR_WIDTH_9BIT), MP_ROM_INT(ADC_WIDTH_9Bit) },
+    { MP_ROM_QSTR(MP_QSTR_WIDTH_10BIT), MP_ROM_INT(ADC_WIDTH_10Bit) },
+    { MP_ROM_QSTR(MP_QSTR_WIDTH_11BIT), MP_ROM_INT(ADC_WIDTH_11Bit) },
+    { MP_ROM_QSTR(MP_QSTR_WIDTH_12BIT), MP_ROM_INT(ADC_WIDTH_12Bit) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(madc_locals_dict, madc_locals_dict_table);

--- a/esp32/machine_adc.c
+++ b/esp32/machine_adc.c
@@ -1,0 +1,127 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Nick Moore
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#include <stdio.h>
+
+#include "esp_log.h"
+
+#include "driver/gpio.h"
+#include "driver/adc.h"
+
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "modmachine.h"
+
+typedef struct _madc_obj_t {
+    mp_obj_base_t base;
+    gpio_num_t gpio_id;
+    adc1_channel_t adc1_id;
+} madc_obj_t;
+
+STATIC const madc_obj_t madc_obj[] = {
+    {{&machine_adc_type}, GPIO_NUM_36, ADC1_CHANNEL_0},
+    {{&machine_adc_type}, GPIO_NUM_37, ADC1_CHANNEL_1},
+    {{&machine_adc_type}, GPIO_NUM_38, ADC1_CHANNEL_2},
+    {{&machine_adc_type}, GPIO_NUM_39, ADC1_CHANNEL_3},
+    {{&machine_adc_type}, GPIO_NUM_32, ADC1_CHANNEL_4},
+    {{&machine_adc_type}, GPIO_NUM_33, ADC1_CHANNEL_5},
+    {{&machine_adc_type}, GPIO_NUM_34, ADC1_CHANNEL_6},
+    {{&machine_adc_type}, GPIO_NUM_35, ADC1_CHANNEL_7},
+};
+
+STATIC mp_obj_t madc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw,
+        const mp_obj_t *args) {
+
+    mp_arg_check_num(n_args, n_kw, 1, 1, true);
+    gpio_num_t pin_id = machine_pin_get_id(args[0]);
+    const madc_obj_t *self = NULL;
+    for (int i=0; i<MP_ARRAY_SIZE(madc_obj); i++) {
+        if (pin_id == madc_obj[i].gpio_id) { self = &madc_obj[i]; break; }
+    }
+    if (!self) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "invalid Pin for ADC"));
+    esp_err_t err = adc1_config_channel_atten(self->adc1_id, ADC_ATTEN_0db);
+    if (err == ESP_OK) return MP_OBJ_FROM_PTR(self);
+    mp_raise_ValueError("Parameter Error");
+}
+
+STATIC void madc_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    madc_obj_t *self = self_in;
+    mp_printf(print, "ADC(Pin(%u))", self->gpio_id);
+}
+
+STATIC mp_obj_t madc_read(mp_obj_t self_in) {
+    madc_obj_t *self = self_in;
+    int val = adc1_get_voltage(self->adc1_id);
+    if (val == -1) mp_raise_ValueError("Parameter Error");
+    return MP_OBJ_NEW_SMALL_INT(val);
+}
+MP_DEFINE_CONST_FUN_OBJ_1(madc_read_obj, madc_read);
+
+STATIC mp_obj_t madc_atten(mp_obj_t self_in, mp_obj_t atten_in) {
+    madc_obj_t *self = self_in;
+    adc_atten_t atten = mp_obj_get_int(atten_in);
+    esp_err_t err = adc1_config_channel_atten(self->adc1_id, atten);
+    if (err == ESP_OK) return mp_const_none;
+    mp_raise_ValueError("Parameter Error");
+}
+MP_DEFINE_CONST_FUN_OBJ_2(madc_atten_obj, madc_atten);
+
+STATIC mp_obj_t madc_width(mp_obj_t self_in, mp_obj_t width_in) {
+    // XXX This should be a classmethod, as there's only one width
+    // across all ADC channels.
+    adc_bits_width_t width = mp_obj_get_int(width_in);
+    esp_err_t err = adc1_config_width(width);
+    if (err == ESP_OK) return mp_const_none;
+    mp_raise_ValueError("Parameter Error");
+}
+MP_DEFINE_CONST_FUN_OBJ_2(madc_width_obj, madc_width);
+
+STATIC const mp_rom_map_elem_t madc_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&madc_read_obj) },
+    { MP_ROM_QSTR(MP_QSTR_atten), MP_ROM_PTR(&madc_atten_obj) },
+    { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&madc_width_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_ATTN_0db), MP_ROM_INT(ADC_ATTEN_0db) },
+    { MP_ROM_QSTR(MP_QSTR_ATTN_2_5db), MP_ROM_INT(ADC_ATTEN_2_5db) },
+    { MP_ROM_QSTR(MP_QSTR_ATTN_6db), MP_ROM_INT(ADC_ATTEN_6db) },
+    { MP_ROM_QSTR(MP_QSTR_ATTN_11db), MP_ROM_INT(ADC_ATTEN_11db) },
+
+    { MP_ROM_QSTR(MP_QSTR_WIDTH_9Bit), MP_ROM_INT(ADC_WIDTH_9Bit) },
+    { MP_ROM_QSTR(MP_QSTR_WIDTH_10Bit), MP_ROM_INT(ADC_WIDTH_10Bit) },
+    { MP_ROM_QSTR(MP_QSTR_WIDTH_11Bit), MP_ROM_INT(ADC_WIDTH_11Bit) },
+    { MP_ROM_QSTR(MP_QSTR_WIDTH_12Bit), MP_ROM_INT(ADC_WIDTH_12Bit) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(madc_locals_dict, madc_locals_dict_table);
+
+const mp_obj_type_t machine_adc_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_ADC,
+    .print = madc_print,
+    .make_new = madc_make_new,
+    .locals_dict = (mp_obj_t)&madc_locals_dict,
+};

--- a/esp32/machine_dac.c
+++ b/esp32/machine_dac.c
@@ -1,0 +1,93 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Nick Moore
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#include <stdio.h>
+
+#include "esp_log.h"
+
+#include "driver/gpio.h"
+#include "driver/dac.h"
+
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "modmachine.h"
+
+typedef struct _mdac_obj_t {
+    mp_obj_base_t base;
+    gpio_num_t gpio_id;
+    dac_channel_t dac_id;
+} mdac_obj_t;
+
+STATIC const mdac_obj_t mdac_obj[] = {
+    {{&machine_dac_type}, GPIO_NUM_25, DAC_CHANNEL_1},
+    {{&machine_dac_type}, GPIO_NUM_26, DAC_CHANNEL_2},
+};
+
+STATIC mp_obj_t mdac_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw,
+        const mp_obj_t *args) {
+
+    mp_arg_check_num(n_args, n_kw, 1, 1, true);
+    gpio_num_t pin_id = machine_pin_get_id(args[0]);
+    const mdac_obj_t *self = NULL;
+    for (int i=0; i<MP_ARRAY_SIZE(mdac_obj); i++) {
+        if (pin_id == mdac_obj[i].gpio_id) { self = &mdac_obj[i]; break; }
+    }
+    if (!self) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "invalid Pin for DAC"));
+    esp_err_t err = dac_out_voltage(self->dac_id, 0);
+    if (err == ESP_OK) return MP_OBJ_FROM_PTR(self);
+    mp_raise_ValueError("Parameter Error");
+}
+
+STATIC void mdac_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    mdac_obj_t *self = self_in;
+    mp_printf(print, "DAC(Pin(%u))", self->gpio_id);
+}
+
+STATIC mp_obj_t mdac_write(mp_obj_t self_in, mp_obj_t value_in) {
+    mdac_obj_t *self = self_in;
+    int value = mp_obj_get_int(value_in);
+    if (value < 0 || value > 255) mp_raise_ValueError("Value out of range");
+
+    esp_err_t err = dac_out_voltage(self->dac_id, value);
+    if (err == ESP_OK) return mp_const_none;
+    mp_raise_ValueError("Parameter Error");
+}
+MP_DEFINE_CONST_FUN_OBJ_2(mdac_write_obj, mdac_write);
+
+STATIC const mp_rom_map_elem_t mdac_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&mdac_write_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(mdac_locals_dict, mdac_locals_dict_table);
+
+const mp_obj_type_t machine_dac_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_DAC,
+    .print = mdac_print,
+    .make_new = mdac_make_new,
+    .locals_dict = (mp_obj_t)&mdac_locals_dict,
+};

--- a/esp32/machine_dac.c
+++ b/esp32/machine_dac.c
@@ -53,7 +53,7 @@ STATIC mp_obj_t mdac_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     mp_arg_check_num(n_args, n_kw, 1, 1, true);
     gpio_num_t pin_id = machine_pin_get_id(args[0]);
     const mdac_obj_t *self = NULL;
-    for (int i=0; i<MP_ARRAY_SIZE(mdac_obj); i++) {
+    for (int i = 0; i < MP_ARRAY_SIZE(mdac_obj); i++) {
         if (pin_id == mdac_obj[i].gpio_id) { self = &mdac_obj[i]; break; }
     }
     if (!self) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "invalid Pin for DAC"));

--- a/esp32/machine_touchpad.c
+++ b/esp32/machine_touchpad.c
@@ -1,0 +1,110 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Nick Moore
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#include <stdio.h>
+
+#include "esp_log.h"
+
+#include "driver/gpio.h"
+#include "driver/touch_pad.h"
+
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "modmachine.h"
+
+typedef struct _mtp_obj_t {
+    mp_obj_base_t base;
+    gpio_num_t gpio_id;
+    touch_pad_t touchpad_id;
+} mtp_obj_t;
+
+STATIC const mtp_obj_t touchpad_obj[] = {
+    {{&machine_touchpad_type}, GPIO_NUM_4, TOUCH_PAD_NUM0},
+    {{&machine_touchpad_type}, GPIO_NUM_0, TOUCH_PAD_NUM1},
+    {{&machine_touchpad_type}, GPIO_NUM_2, TOUCH_PAD_NUM2},
+    {{&machine_touchpad_type}, GPIO_NUM_15, TOUCH_PAD_NUM3},
+    {{&machine_touchpad_type}, GPIO_NUM_13, TOUCH_PAD_NUM4},
+    {{&machine_touchpad_type}, GPIO_NUM_12, TOUCH_PAD_NUM5},
+    {{&machine_touchpad_type}, GPIO_NUM_14, TOUCH_PAD_NUM6},
+    {{&machine_touchpad_type}, GPIO_NUM_27, TOUCH_PAD_NUM7},
+    {{&machine_touchpad_type}, GPIO_NUM_33, TOUCH_PAD_NUM8},
+    {{&machine_touchpad_type}, GPIO_NUM_32, TOUCH_PAD_NUM9},
+};
+
+STATIC mp_obj_t mtp_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw,
+        const mp_obj_t *args) {
+
+    mp_arg_check_num(n_args, n_kw, 1, 1, true);
+    gpio_num_t pin_id = machine_pin_get_id(args[0]);
+    const mtp_obj_t *self = NULL;
+    for (int i=0; i<MP_ARRAY_SIZE(touchpad_obj); i++) {
+        if (pin_id == touchpad_obj[i].gpio_id) { self = &touchpad_obj[i]; break; }
+    }
+    if (!self) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "invalid pin for touchpad"));
+
+    static int initialized = 0;
+    if (!initialized) {
+        touch_pad_init();
+        initialized = 1;
+    }
+    esp_err_t err = touch_pad_config(self->touchpad_id, 0);
+    if (err == ESP_OK) return MP_OBJ_FROM_PTR(self);
+    mp_raise_ValueError("Touch pad error");
+}
+
+STATIC mp_obj_t mtp_config(mp_obj_t self_in, mp_obj_t value_in) {
+    mtp_obj_t *self = self_in;
+    uint16_t value = mp_obj_get_int(value_in);
+    esp_err_t err = touch_pad_config(self->touchpad_id, value);
+    if (err == ESP_OK) return mp_const_none;
+    mp_raise_ValueError("Touch pad error");
+}
+MP_DEFINE_CONST_FUN_OBJ_2(mtp_config_obj, mtp_config);
+
+STATIC mp_obj_t mtp_read(mp_obj_t self_in) {
+    mtp_obj_t *self = self_in;
+    uint16_t value;
+    esp_err_t err = touch_pad_read(self->touchpad_id, &value);
+    if (err == ESP_OK) return MP_OBJ_NEW_SMALL_INT(value);
+    mp_raise_ValueError("Touch pad error");
+}
+MP_DEFINE_CONST_FUN_OBJ_1(mtp_read_obj, mtp_read);
+
+STATIC const mp_rom_map_elem_t mtp_locals_dict_table[] = {
+    // instance methods
+    { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&mtp_config_obj) },
+    { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&mtp_read_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(mtp_locals_dict, mtp_locals_dict_table);
+
+const mp_obj_type_t machine_touchpad_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_TouchPad,
+    .make_new = mtp_make_new,
+    .locals_dict = (mp_obj_t)&mtp_locals_dict,
+};

--- a/esp32/machine_touchpad.c
+++ b/esp32/machine_touchpad.c
@@ -61,7 +61,7 @@ STATIC mp_obj_t mtp_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
     mp_arg_check_num(n_args, n_kw, 1, 1, true);
     gpio_num_t pin_id = machine_pin_get_id(args[0]);
     const mtp_obj_t *self = NULL;
-    for (int i=0; i<MP_ARRAY_SIZE(touchpad_obj); i++) {
+    for (int i = 0; i < MP_ARRAY_SIZE(touchpad_obj); i++) {
         if (pin_id == touchpad_obj[i].gpio_id) { self = &touchpad_obj[i]; break; }
     }
     if (!self) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "invalid pin for touchpad"));

--- a/esp32/modmachine.c
+++ b/esp32/modmachine.c
@@ -91,6 +91,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_Pin), MP_ROM_PTR(&machine_pin_type) },
     { MP_ROM_QSTR(MP_QSTR_TouchPad), MP_ROM_PTR(&machine_touchpad_type) },
+    { MP_ROM_QSTR(MP_QSTR_ADC), MP_ROM_PTR(&machine_adc_type) },
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&machine_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&mp_machine_soft_spi_type) },
 };

--- a/esp32/modmachine.c
+++ b/esp32/modmachine.c
@@ -92,6 +92,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_Pin), MP_ROM_PTR(&machine_pin_type) },
     { MP_ROM_QSTR(MP_QSTR_TouchPad), MP_ROM_PTR(&machine_touchpad_type) },
     { MP_ROM_QSTR(MP_QSTR_ADC), MP_ROM_PTR(&machine_adc_type) },
+    { MP_ROM_QSTR(MP_QSTR_DAC), MP_ROM_PTR(&machine_dac_type) },
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&machine_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&mp_machine_soft_spi_type) },
 };

--- a/esp32/modmachine.c
+++ b/esp32/modmachine.c
@@ -90,6 +90,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_time_pulse_us), MP_ROM_PTR(&machine_time_pulse_us_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_Pin), MP_ROM_PTR(&machine_pin_type) },
+    { MP_ROM_QSTR(MP_QSTR_TouchPad), MP_ROM_PTR(&machine_touchpad_type) },
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&machine_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&mp_machine_soft_spi_type) },
 };

--- a/esp32/modmachine.h
+++ b/esp32/modmachine.h
@@ -4,5 +4,8 @@
 #include "py/obj.h"
 
 extern const mp_obj_type_t machine_pin_type;
+extern const mp_obj_type_t machine_touchpad_type;
+extern const mp_obj_type_t machine_adc_type;
+extern const mp_obj_type_t machine_dac_type;
 
 #endif // MICROPY_INCLUDED_ESP32_MODMACHINE_H


### PR DESCRIPTION
This provides support for machine.TouchPad, machine.ADC and machine.DAC classes, like so:

```
import machine

t = machine.TouchPad(machine.Pin(12))
t.read()

a = machine.ADC(machine.Pin(33))
a.width(machine.ADC.WIDTH_11Bit)
a.read()

d = machine.DAC(machine.Pin(25))
d.write(128)
```

I haven't included IRQ handling for TouchPad or Pin, I'll put that in as a separate PR later.