### PR TITLE
esp32/Makefile: add target for combined.bin

### DIFF
--- a/esp32/Makefile
+++ b/esp32/Makefile
@@ -575,6 +575,12 @@ $(BUILD)/application.elf: $(OBJ) $(BUILD)/esp32_out.ld
 	$(Q)$(LD) $(LDFLAGS) -o $@ $(APP_LD_ARGS)
 	$(Q)$(SIZE) $@
 
+$(BUILD)/combined.bin: $(BUILD)/bootloader.bin $(BUILD)/partitions.bin $(BUILD)/application.bin
+	dd if=/dev/zero of=$@ bs=4096 count=1
+	dd if=$(BUILD)/bootloader.bin of=$@ bs=28672 count=1 conv=notrunc,sync oflag=append
+	dd if=$(BUILD)/partitions.bin of=$@ bs=32768 count=1 conv=notrunc,sync oflag=append
+	dd if=$(BUILD)/application.bin of=$@ conv=notrunc oflag=append
+
 define compile_cxx
 $(ECHO) "CXX $<"
 $(Q)$(CXX) $(CXXFLAGS) -c -MD -o $@ $<


### PR DESCRIPTION
This is a useful target if you want to burn the whole thing in one go: see #14 for the confusion which can occur.  It isn't a particularly beautiful way to do it, admittedly.