### PR TITLE
esp32/modules/inisetup.py: Mount filesystem at /flash like ESP8266

### DIFF
--- a/esp32/modules/inisetup.py
+++ b/esp32/modules/inisetup.py
@@ -28,8 +28,10 @@ def setup():
     check_bootsec()
     print("Performing initial setup")
     uos.VfsFat.mkfs(bdev)
-    vfs = uos.VfsFat(bdev, "")
-    with open("/boot.py", "w") as f:
+    vfs = uos.VfsFat(bdev)
+    uos.mount(vfs, '/flash')
+    uos.chdir('/flash')
+    with open("boot.py", "w") as f:
         f.write("""\
 # This file is executed on every boot (including wake-boot from deepsleep)
 """)


### PR DESCRIPTION
I think ESP32 should be as close as possible to ESP8266 so I changed the inisetup in order to mount the flash memory at /flash.