### PR TITLE
Initial port of machine.UART.

### DIFF
--- a/esp32/Makefile
+++ b/esp32/Makefile
@@ -123,6 +123,7 @@ SRC_C = \
 	machine_touchpad.c \
 	machine_adc.c \
 	machine_dac.c \
+	machine_uart.c \
 	modmachine.c \
 	modnetwork.c \
 	modsocket.c \

--- a/esp32/machine_uart.c
+++ b/esp32/machine_uart.c
@@ -39,7 +39,7 @@
 // UartDev is defined and initialized in rom code.
 extern UartDevice UartDev;
 
-typedef struct _pyb_uart_obj_t {
+typedef struct _machine_uart_obj_t {
     mp_obj_base_t base;
     uint8_t uart_id;
     uint8_t bits;
@@ -48,21 +48,21 @@ typedef struct _pyb_uart_obj_t {
     uint32_t baudrate;
     uint16_t timeout;       // timeout waiting for first char (in ms)
     uint16_t timeout_char;  // timeout waiting between chars (in ms)
-} pyb_uart_obj_t;
+} machine_uart_obj_t;
 
 STATIC const char *_parity_name[] = {"None", "1", "0"};
 
 /******************************************************************************/
 // MicroPython bindings for UART
 
-STATIC void pyb_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    pyb_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
+STATIC void machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_printf(print, "UART(%u, baudrate=%u, bits=%u, parity=%s, stop=%u, timeout=%u, timeout_char=%u)",
         self->uart_id, self->baudrate, self->bits, _parity_name[self->parity],
         self->stop, self->timeout, self->timeout_char);
 }
 
-STATIC void pyb_uart_init_helper(pyb_uart_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_baudrate, ARG_bits, ARG_parity, ARG_stop, ARG_timeout, ARG_timeout_char };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_baudrate, MP_ARG_INT, {.u_int = 0} },
@@ -159,7 +159,7 @@ STATIC void pyb_uart_init_helper(pyb_uart_obj_t *self, size_t n_args, const mp_o
     uart_setup(self->uart_id);
 }
 
-STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
 
     // get uart id
@@ -169,8 +169,8 @@ STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, size_t n_args, size
     }
 
     // create instance
-    pyb_uart_obj_t *self = m_new_obj(pyb_uart_obj_t);
-    self->base.type = &pyb_uart_type;
+    machine_uart_obj_t *self = m_new_obj(machine_uart_obj_t);
+    self->base.type = &machine_uart_type;
     self->uart_id = uart_id;
     self->baudrate = 115200;
     self->bits = 8;
@@ -182,19 +182,19 @@ STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, size_t n_args, size
     // init the peripheral
     mp_map_t kw_args;
     mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
-    pyb_uart_init_helper(self, n_args - 1, args + 1, &kw_args);
+    machine_uart_init_helper(self, n_args - 1, args + 1, &kw_args);
 
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC mp_obj_t pyb_uart_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
-    pyb_uart_init_helper(args[0], n_args - 1, args + 1, kw_args);
+STATIC mp_obj_t machine_uart_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    machine_uart_init_helper(args[0], n_args - 1, args + 1, kw_args);
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_KW(pyb_uart_init_obj, 1, pyb_uart_init);
+MP_DEFINE_CONST_FUN_OBJ_KW(machine_uart_init_obj, 1, machine_uart_init);
 
-STATIC const mp_rom_map_elem_t pyb_uart_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&pyb_uart_init_obj) },
+STATIC const mp_rom_map_elem_t machine_uart_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_uart_init_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&mp_stream_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_readline), MP_ROM_PTR(&mp_stream_unbuffered_readline_obj) },
@@ -202,10 +202,10 @@ STATIC const mp_rom_map_elem_t pyb_uart_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&mp_stream_write_obj) },
 };
 
-STATIC MP_DEFINE_CONST_DICT(pyb_uart_locals_dict, pyb_uart_locals_dict_table);
+STATIC MP_DEFINE_CONST_DICT(machine_uart_locals_dict, machine_uart_locals_dict_table);
 
-STATIC mp_uint_t pyb_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {
-    pyb_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
+STATIC mp_uint_t machine_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {
+    machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     if (self->uart_id == 1) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, "UART(1) can't read"));
@@ -233,8 +233,8 @@ STATIC mp_uint_t pyb_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, i
     }
 }
 
-STATIC mp_uint_t pyb_uart_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
-    pyb_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
+STATIC mp_uint_t machine_uart_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
+    machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
     const byte *buf = buf_in;
 
     /* TODO implement non-blocking
@@ -254,8 +254,8 @@ STATIC mp_uint_t pyb_uart_write(mp_obj_t self_in, const void *buf_in, mp_uint_t 
     return size;
 }
 
-STATIC mp_uint_t pyb_uart_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint_t arg, int *errcode) {
-    pyb_uart_obj_t *self = self_in;
+STATIC mp_uint_t machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint_t arg, int *errcode) {
+    machine_uart_obj_t *self = self_in;
     mp_uint_t ret;
     if (request == MP_STREAM_POLL) {
         mp_uint_t flags = arg;
@@ -274,19 +274,19 @@ STATIC mp_uint_t pyb_uart_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint_t a
 }
 
 STATIC const mp_stream_p_t uart_stream_p = {
-    .read = pyb_uart_read,
-    .write = pyb_uart_write,
-    .ioctl = pyb_uart_ioctl,
+    .read = machine_uart_read,
+    .write = machine_uart_write,
+    .ioctl = machine_uart_ioctl,
     .is_text = false,
 };
 
-const mp_obj_type_t pyb_uart_type = {
+const mp_obj_type_t machine_uart_type = {
     { &mp_type_type },
     .name = MP_QSTR_UART,
-    .print = pyb_uart_print,
-    .make_new = pyb_uart_make_new,
+    .print = machine_uart_print,
+    .make_new = machine_uart_make_new,
     .getiter = mp_identity_getiter,
     .iternext = mp_stream_unbuffered_iter,
     .protocol = &uart_stream_p,
-    .locals_dict = (mp_obj_dict_t*)&pyb_uart_locals_dict,
+    .locals_dict = (mp_obj_dict_t*)&machine_uart_locals_dict,
 };

--- a/esp32/machine_uart.c
+++ b/esp32/machine_uart.c
@@ -1,0 +1,292 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "ets_sys.h"
+#include "uart.h"
+
+#include "py/runtime.h"
+#include "py/stream.h"
+#include "py/mperrno.h"
+#include "modmachine.h"
+
+// UartDev is defined and initialized in rom code.
+extern UartDevice UartDev;
+
+typedef struct _pyb_uart_obj_t {
+    mp_obj_base_t base;
+    uint8_t uart_id;
+    uint8_t bits;
+    uint8_t parity;
+    uint8_t stop;
+    uint32_t baudrate;
+    uint16_t timeout;       // timeout waiting for first char (in ms)
+    uint16_t timeout_char;  // timeout waiting between chars (in ms)
+} pyb_uart_obj_t;
+
+STATIC const char *_parity_name[] = {"None", "1", "0"};
+
+/******************************************************************************/
+// MicroPython bindings for UART
+
+STATIC void pyb_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    pyb_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "UART(%u, baudrate=%u, bits=%u, parity=%s, stop=%u, timeout=%u, timeout_char=%u)",
+        self->uart_id, self->baudrate, self->bits, _parity_name[self->parity],
+        self->stop, self->timeout, self->timeout_char);
+}
+
+STATIC void pyb_uart_init_helper(pyb_uart_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_baudrate, ARG_bits, ARG_parity, ARG_stop, ARG_timeout, ARG_timeout_char };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_baudrate, MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_bits, MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_parity, MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_stop, MP_ARG_INT, {.u_int = 0} },
+        //{ MP_QSTR_tx, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        //{ MP_QSTR_rx, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_timeout_char, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // set baudrate
+    if (args[ARG_baudrate].u_int > 0) {
+        self->baudrate = args[ARG_baudrate].u_int;
+        UartDev.baut_rate = self->baudrate; // Sic!
+    }
+
+    // set data bits
+    switch (args[ARG_bits].u_int) {
+        case 0:
+            break;
+        case 5:
+            UartDev.data_bits = UART_FIVE_BITS;
+            self->bits = 5;
+            break;
+        case 6:
+            UartDev.data_bits = UART_SIX_BITS;
+            self->bits = 6;
+            break;
+        case 7:
+            UartDev.data_bits = UART_SEVEN_BITS;
+            self->bits = 7;
+            break;
+        case 8:
+            UartDev.data_bits = UART_EIGHT_BITS;
+            self->bits = 8;
+            break;
+        default:
+            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid data bits"));
+            break;
+    }
+
+    // set parity
+    if (args[ARG_parity].u_obj != MP_OBJ_NULL) {
+        if (args[ARG_parity].u_obj == mp_const_none) {
+            UartDev.parity = UART_NONE_BITS;
+            UartDev.exist_parity = UART_STICK_PARITY_DIS;
+            self->parity = 0;
+        } else {
+            mp_int_t parity = mp_obj_get_int(args[ARG_parity].u_obj);
+            UartDev.exist_parity = UART_STICK_PARITY_EN;
+            if (parity & 1) {
+                UartDev.parity = UART_ODD_BITS;
+                self->parity = 1;
+            } else {
+                UartDev.parity = UART_EVEN_BITS;
+                self->parity = 2;
+            }
+        }
+    }
+
+    // set stop bits
+    switch (args[ARG_stop].u_int) {
+        case 0:
+            break;
+        case 1:
+            UartDev.stop_bits = UART_ONE_STOP_BIT;
+            self->stop = 1;
+            break;
+        case 2:
+            UartDev.stop_bits = UART_TWO_STOP_BIT;
+            self->stop = 2;
+            break;
+        default:
+            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid stop bits"));
+            break;
+    }
+
+    // set timeout
+    self->timeout = args[ARG_timeout].u_int;
+
+    // set timeout_char
+    // make sure it is at least as long as a whole character (13 bits to be safe)
+    self->timeout_char = args[ARG_timeout_char].u_int;
+    uint32_t min_timeout_char = 13000 / self->baudrate + 1;
+    if (self->timeout_char < min_timeout_char) {
+        self->timeout_char = min_timeout_char;
+    }
+
+    // setup
+    uart_setup(self->uart_id);
+}
+
+STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
+
+    // get uart id
+    mp_int_t uart_id = mp_obj_get_int(args[0]);
+    if (uart_id != 0 && uart_id != 1) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "UART(%d) does not exist", uart_id));
+    }
+
+    // create instance
+    pyb_uart_obj_t *self = m_new_obj(pyb_uart_obj_t);
+    self->base.type = &pyb_uart_type;
+    self->uart_id = uart_id;
+    self->baudrate = 115200;
+    self->bits = 8;
+    self->parity = 0;
+    self->stop = 1;
+    self->timeout = 0;
+    self->timeout_char = 0;
+
+    // init the peripheral
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+    pyb_uart_init_helper(self, n_args - 1, args + 1, &kw_args);
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+STATIC mp_obj_t pyb_uart_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    pyb_uart_init_helper(args[0], n_args - 1, args + 1, kw_args);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(pyb_uart_init_obj, 1, pyb_uart_init);
+
+STATIC const mp_rom_map_elem_t pyb_uart_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&pyb_uart_init_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&mp_stream_read_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readline), MP_ROM_PTR(&mp_stream_unbuffered_readline_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&mp_stream_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&mp_stream_write_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(pyb_uart_locals_dict, pyb_uart_locals_dict_table);
+
+STATIC mp_uint_t pyb_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {
+    pyb_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    if (self->uart_id == 1) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, "UART(1) can't read"));
+    }
+
+    // make sure we want at least 1 char
+    if (size == 0) {
+        return 0;
+    }
+
+    // wait for first char to become available
+    if (!uart_rx_wait(self->timeout * 1000)) {
+        *errcode = MP_EAGAIN;
+        return MP_STREAM_ERROR;
+    }
+
+    // read the data
+    uint8_t *buf = buf_in;
+    for (;;) {
+        *buf++ = uart_rx_char();
+        if (--size == 0 || !uart_rx_wait(self->timeout_char * 1000)) {
+            // return number of bytes read
+            return buf - (uint8_t*)buf_in;
+        }
+    }
+}
+
+STATIC mp_uint_t pyb_uart_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
+    pyb_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    const byte *buf = buf_in;
+
+    /* TODO implement non-blocking
+    // wait to be able to write the first character
+    if (!uart_tx_wait(self, timeout)) {
+        *errcode = EAGAIN;
+        return MP_STREAM_ERROR;
+    }
+    */
+
+    // write the data
+    for (size_t i = 0; i < size; ++i) {
+        uart_tx_one_char(self->uart_id, *buf++);
+    }
+
+    // return number of bytes written
+    return size;
+}
+
+STATIC mp_uint_t pyb_uart_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint_t arg, int *errcode) {
+    pyb_uart_obj_t *self = self_in;
+    mp_uint_t ret;
+    if (request == MP_STREAM_POLL) {
+        mp_uint_t flags = arg;
+        ret = 0;
+        if ((flags & MP_STREAM_POLL_RD) && uart_rx_any(self->uart_id)) {
+            ret |= MP_STREAM_POLL_RD;
+        }
+        if ((flags & MP_STREAM_POLL_WR) && uart_tx_any_room(self->uart_id)) {
+            ret |= MP_STREAM_POLL_WR;
+        }
+    } else {
+        *errcode = MP_EINVAL;
+        ret = MP_STREAM_ERROR;
+    }
+    return ret;
+}
+
+STATIC const mp_stream_p_t uart_stream_p = {
+    .read = pyb_uart_read,
+    .write = pyb_uart_write,
+    .ioctl = pyb_uart_ioctl,
+    .is_text = false,
+};
+
+const mp_obj_type_t pyb_uart_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_UART,
+    .print = pyb_uart_print,
+    .make_new = pyb_uart_make_new,
+    .getiter = mp_identity_getiter,
+    .iternext = mp_stream_unbuffered_iter,
+    .protocol = &uart_stream_p,
+    .locals_dict = (mp_obj_dict_t*)&pyb_uart_locals_dict,
+};

--- a/esp32/machine_uart.c
+++ b/esp32/machine_uart.c
@@ -28,24 +28,26 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "ets_sys.h"
-#include "uart.h"
+#include "driver/uart.h"
+#include "freertos/FreeRTOS.h"
 
 #include "py/runtime.h"
 #include "py/stream.h"
 #include "py/mperrno.h"
 #include "modmachine.h"
 
-// UartDev is defined and initialized in rom code.
-extern UartDevice UartDev;
-
 typedef struct _machine_uart_obj_t {
     mp_obj_base_t base;
-    uint8_t uart_id;
+    uart_port_t uart_num;
     uint8_t bits;
     uint8_t parity;
     uint8_t stop;
     uint32_t baudrate;
+    // TODO: implement pins; tx, rx, rts, cts
+    int8_t tx;
+    int8_t rx;
+    int8_t rts;
+    int8_t cts;
     uint16_t timeout;       // timeout waiting for first char (in ms)
     uint16_t timeout_char;  // timeout waiting between chars (in ms)
 } machine_uart_obj_t;
@@ -58,49 +60,83 @@ STATIC const char *_parity_name[] = {"None", "1", "0"};
 STATIC void machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_printf(print, "UART(%u, baudrate=%u, bits=%u, parity=%s, stop=%u, timeout=%u, timeout_char=%u)",
-        self->uart_id, self->baudrate, self->bits, _parity_name[self->parity],
+        self->uart_num, self->baudrate, self->bits, _parity_name[self->parity],
         self->stop, self->timeout, self->timeout_char);
 }
 
+// https://github.com/espressif/esp-idf/blob/9050307dfe600c915adaccf8076220d6474876db/components/driver/uart.c#L359
 STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_baudrate, ARG_bits, ARG_parity, ARG_stop, ARG_timeout, ARG_timeout_char };
+    enum { ARG_baudrate, ARG_bits, ARG_parity, ARG_stop, ARG_tx, ARG_rx, ARG_rts, ARG_cts, ARG_timeout, ARG_timeout_char };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_baudrate, MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_bits, MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_parity, MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_stop, MP_ARG_INT, {.u_int = 0} },
-        //{ MP_QSTR_tx, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
-        //{ MP_QSTR_rx, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_tx, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = UART_PIN_NO_CHANGE} },
+        { MP_QSTR_rx, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = UART_PIN_NO_CHANGE} },
+        { MP_QSTR_rts, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = UART_PIN_NO_CHANGE} },
+        { MP_QSTR_cts, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = UART_PIN_NO_CHANGE} },
         { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_timeout_char, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
+     // Defaults
+    uart_config_t uartcfg = {
+        .baud_rate = 115200,
+        .data_bits = UART_DATA_8_BITS,
+        .parity = UART_PARITY_DISABLE,
+        .stop_bits = UART_STOP_BITS_1,
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+        .rx_flow_ctrl_thresh = 0
+    };
+    
     // set baudrate
     if (args[ARG_baudrate].u_int > 0) {
         self->baudrate = args[ARG_baudrate].u_int;
-        UartDev.baut_rate = self->baudrate; // Sic!
+        uartcfg.baud_rate = self->baudrate;
+        //uart_set_baudrate(self->uart_num, self->baudrate);
     }
-
+    
+    uart_set_pin(self->uart_num, args[ARG_tx].u_int, args[ARG_rx].u_int, args[ARG_rts].u_int, args[ARG_cts].u_int);
+    if (args[ARG_tx].u_int != UART_PIN_NO_CHANGE) {
+        self->tx = args[ARG_tx].u_int;
+    }
+    
+    if (args[ARG_rx].u_int != UART_PIN_NO_CHANGE) {
+        self->rx = args[ARG_rx].u_int;
+    }
+    
+    if (args[ARG_rts].u_int != UART_PIN_NO_CHANGE) {
+        self->rts = args[ARG_rts].u_int;
+    }
+    
+    if (args[ARG_cts].u_int != UART_PIN_NO_CHANGE) {
+        self->cts = args[ARG_cts].u_int;
+    }
     // set data bits
     switch (args[ARG_bits].u_int) {
         case 0:
             break;
         case 5:
-            UartDev.data_bits = UART_FIVE_BITS;
+            //uart_set_word_length(self->uart_num, UART_DATA_5_BITS);
+            uartcfg.data_bits = UART_DATA_5_BITS;
             self->bits = 5;
             break;
         case 6:
-            UartDev.data_bits = UART_SIX_BITS;
+            //uart_set_word_length(self->uart_num, UART_DATA_6_BITS);
+            uartcfg.data_bits = UART_DATA_6_BITS;
             self->bits = 6;
             break;
         case 7:
-            UartDev.data_bits = UART_SEVEN_BITS;
+            //uart_set_word_length(self->uart_num, UART_DATA_7_BITS);
+            uartcfg.data_bits = UART_DATA_7_BITS;
             self->bits = 7;
             break;
         case 8:
-            UartDev.data_bits = UART_EIGHT_BITS;
+            //uart_set_word_length(self->uart_num, UART_DATA_8_BITS);
+            uartcfg.data_bits = UART_DATA_8_BITS;
             self->bits = 8;
             break;
         default:
@@ -111,17 +147,18 @@ STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, co
     // set parity
     if (args[ARG_parity].u_obj != MP_OBJ_NULL) {
         if (args[ARG_parity].u_obj == mp_const_none) {
-            UartDev.parity = UART_NONE_BITS;
-            UartDev.exist_parity = UART_STICK_PARITY_DIS;
+            //uart_set_parity(self->uart_num, UART_PARITY_DISABLE);
+            uartcfg.parity = UART_PARITY_DISABLE;
             self->parity = 0;
         } else {
             mp_int_t parity = mp_obj_get_int(args[ARG_parity].u_obj);
-            UartDev.exist_parity = UART_STICK_PARITY_EN;
             if (parity & 1) {
-                UartDev.parity = UART_ODD_BITS;
+                //uart_set_parity(self->uart_num, UART_PARITY_ODD);
+                uartcfg.parity = UART_PARITY_ODD;
                 self->parity = 1;
             } else {
-                UartDev.parity = UART_EVEN_BITS;
+                //uart_set_parity(self->uart_num, UART_PARITY_EVEN);
+                uartcfg.parity = UART_PARITY_EVEN;
                 self->parity = 2;
             }
         }
@@ -129,14 +166,17 @@ STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, co
 
     // set stop bits
     switch (args[ARG_stop].u_int) {
+        // FIXME: ESP32 also supports 1.5 stop bits
         case 0:
             break;
         case 1:
-            UartDev.stop_bits = UART_ONE_STOP_BIT;
+            //uart_set_stop_bits(self->uart_num, UART_STOP_BITS_1);
+            uartcfg.stop_bits = UART_STOP_BITS_1;
             self->stop = 1;
             break;
         case 2:
-            UartDev.stop_bits = UART_TWO_STOP_BIT;
+            //uart_set_stop_bits(self->uart_num, UART_STOP_BITS_2);
+            uartcfg.stop_bits = UART_STOP_BITS_2;
             self->stop = 2;
             break;
         default:
@@ -156,22 +196,30 @@ STATIC void machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, co
     }
 
     // setup
-    uart_setup(self->uart_id);
+    uart_param_config(self->uart_num, &uartcfg);
+    
+    // This should probably be located in make_new;
+    // https://github.com/espressif/esp-idf/blob/9050307dfe600c915adaccf8076220d6474876db/components/driver/include/driver/uart.h#L468
+    uart_driver_install(self->uart_num, 256, 0, 0, NULL, 0);
+    // FIXME: Do we want to use FreeRTOS's queue handler?
+    // https://github.com/espressif/esp-idf/blob/master/components/freertos/include/freertos/queue.h
+    //QueueHandle_t uart_queue;
+    //uart_driver_install(uart_num, 1024 * 2, 1024 * 2, 10, &uart_queue, 0);
 }
 
 STATIC mp_obj_t machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
 
     // get uart id
-    mp_int_t uart_id = mp_obj_get_int(args[0]);
-    if (uart_id != 0 && uart_id != 1) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "UART(%d) does not exist", uart_id));
+    mp_int_t uart_num = mp_obj_get_int(args[0]);
+    if (uart_num < 0 || uart_num > UART_NUM_MAX) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "UART(%d) does not exist", uart_num));
     }
 
     // create instance
     machine_uart_obj_t *self = m_new_obj(machine_uart_obj_t);
     self->base.type = &machine_uart_type;
-    self->uart_id = uart_id;
+    self->uart_num = uart_num;
     self->baudrate = 115200;
     self->bits = 8;
     self->parity = 0;
@@ -207,51 +255,38 @@ STATIC MP_DEFINE_CONST_DICT(machine_uart_locals_dict, machine_uart_locals_dict_t
 STATIC mp_uint_t machine_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
-    if (self->uart_id == 1) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, "UART(1) can't read"));
-    }
+    //if (self->uart_num == 1) {
+    //    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, "UART(1) can't read"));
+    //}
 
     // make sure we want at least 1 char
     if (size == 0) {
         return 0;
     }
-
-    // wait for first char to become available
-    if (!uart_rx_wait(self->timeout * 1000)) {
+    
+    TickType_t time_to_wait = pdMS_TO_TICKS(self->timeout * 1000);
+    int bytes_read = uart_read_bytes(self->uart_num, buf_in, size, time_to_wait);
+    
+    if (bytes_read < 0) {
         *errcode = MP_EAGAIN;
         return MP_STREAM_ERROR;
     }
-
-    // read the data
-    uint8_t *buf = buf_in;
-    for (;;) {
-        *buf++ = uart_rx_char();
-        if (--size == 0 || !uart_rx_wait(self->timeout_char * 1000)) {
-            // return number of bytes read
-            return buf - (uint8_t*)buf_in;
-        }
-    }
+    // TODO: what exactly does uart_read_bytes return?
+    return bytes_read;
 }
 
 STATIC mp_uint_t machine_uart_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    const byte *buf = buf_in;
 
-    /* TODO implement non-blocking
-    // wait to be able to write the first character
-    if (!uart_tx_wait(self, timeout)) {
-        *errcode = EAGAIN;
+    int bytes_written = uart_write_bytes(self->uart_num, buf_in, size);
+    
+    if (bytes_written < 0) {
+        *errcode = MP_EAGAIN;
         return MP_STREAM_ERROR;
     }
-    */
-
-    // write the data
-    for (size_t i = 0; i < size; ++i) {
-        uart_tx_one_char(self->uart_id, *buf++);
-    }
-
+    
     // return number of bytes written
-    return size;
+    return bytes_written;
 }
 
 STATIC mp_uint_t machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint_t arg, int *errcode) {
@@ -260,10 +295,12 @@ STATIC mp_uint_t machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint
     if (request == MP_STREAM_POLL) {
         mp_uint_t flags = arg;
         ret = 0;
-        if ((flags & MP_STREAM_POLL_RD) && uart_rx_any(self->uart_id)) {
+        size_t rxbufsize;
+        uart_get_buffered_data_len(self->uart_num, &rxbufsize);
+        if ((flags & MP_STREAM_POLL_RD) && rxbufsize > 0) {
             ret |= MP_STREAM_POLL_RD;
         }
-        if ((flags & MP_STREAM_POLL_WR) && uart_tx_any_room(self->uart_id)) {
+        if ((flags & MP_STREAM_POLL_WR) && 1) { // FIXME: uart_tx_any_room(self->uart_num)
             ret |= MP_STREAM_POLL_WR;
         }
     } else {

--- a/esp32/modmachine.c
+++ b/esp32/modmachine.c
@@ -119,6 +119,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_DAC), MP_ROM_PTR(&machine_dac_type) },
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&machine_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&mp_machine_soft_spi_type) },
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&machine_uart_type) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(machine_module_globals, machine_module_globals_table);

--- a/esp32/modmachine.h
+++ b/esp32/modmachine.h
@@ -8,6 +8,7 @@ extern const mp_obj_type_t machine_touchpad_type;
 extern const mp_obj_type_t machine_adc_type;
 extern const mp_obj_type_t machine_dac_type;
 extern const mp_obj_type_t machine_hw_spi_type;
+extern const mp_obj_type_t machine_uart_type;
 
 void machine_pins_init(void);
 void machine_pins_deinit(void);


### PR DESCRIPTION
<del>Not yet ready to merge.</del>
See micropython/micropython-esp32#78


### TODO
- [x] Rebase on top of the plain ESP8266 machine_uart.c file, to better show changes made.
- [x] Move `uart_driver_install` into `machine_uart_make_new`.
- [x] Handle default UART pins when no `rx `or `tx` is provided.
- [x] Update `machine_uart_print` to reflect new parameters.
- [ ] Fix `machine_uart_ioctl` - currently does not check if the tx buffer has any room.
- [x] Update only changed settings in `machine_uart_init_helper`.
- [ ] timeout_char is currently not used. Either remove argument or find a way to implement this.
- [x] Hunt for sneaky `'\t'` (Fix whitespace issues)
