### PR TITLE
esp32/README.md: Added note about btree submodule initialization

### DIFF
--- a/esp32/README.md
+++ b/esp32/README.md
@@ -83,6 +83,15 @@ this repository):
 $ make -C mpy-cross
 ```
 
+The ESP32 port has a dependency on Berkeley DB, which is an external
+dependency (git submodule). You'll need to have git initialize that
+module:
+
+```
+$ git submodule init lib/berkeley-db-1.xx
+$ git submodule update
+```
+
 Then to build MicroPython for the ESP32 run:
 ```bash
 $ cd esp32


### PR DESCRIPTION
Recent changes to this repo now require that a previously unused git submodule be initialized to actually compile for the ESP32.  This is a documentation change.

The repo root README.md only mentions that the submodules are needed to compile the _unix_ port.
