### PR TITLE
py/binary.c: Bugfix for struct.pack('>Q', 16)

### DIFF
--- a/py/binary.c
+++ b/py/binary.c
@@ -303,7 +303,12 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte **
                 // zero/sign extend if needed
                 if (BYTES_PER_WORD < 8 && size > sizeof(val)) {
                     int c = (is_signed(val_type) && (mp_int_t)val < 0) ? 0xff : 0x00;
-                    memset(p + sizeof(val), c, size - sizeof(val));
+                    if (struct_type == '>') {
+                        memset(p, c, size - sizeof(val));
+                        p += size - sizeof(val);
+                    } else {
+                        memset(p + sizeof(val), c, size - sizeof(val));
+                    }
                 }
             }
     }


### PR DESCRIPTION
Without bugfix:

    struct.pack('>Q', 16)
    b'\x00\x00\x00\x10\x00\x00\x00\x00'

With bugfix:

    struct.pack('>Q', 16)
    b'\x00\x00\x00\x00\x00\x00\x00\x10'