### PR TITLE
ports/esp32/mphalport.h: mp_hal_pin_<dir> will not select pin as GPIO

### DIFF
--- a/ports/esp32/mphalport.h
+++ b/ports/esp32/mphalport.h
@@ -59,12 +59,15 @@ mp_hal_pin_obj_t machine_pin_get_id(mp_obj_t pin_in);
 #define mp_obj_get_pin(o) machine_pin_get_id(o) // legacy name; only to support esp8266/modonewire
 #define mp_hal_pin_name(p) (p)
 static inline void mp_hal_pin_input(mp_hal_pin_obj_t pin) {
+    gpio_pad_select_gpio(pin);
     gpio_set_direction(pin, GPIO_MODE_INPUT);
 }
 static inline void mp_hal_pin_output(mp_hal_pin_obj_t pin) {
+    gpio_pad_select_gpio(pin);
     gpio_set_direction(pin, GPIO_MODE_INPUT_OUTPUT);
 }
 static inline void mp_hal_pin_open_drain(mp_hal_pin_obj_t pin) {
+    gpio_pad_select_gpio(pin);
     gpio_set_direction(pin, GPIO_MODE_INPUT_OUTPUT_OD);
 }
 static inline void mp_hal_pin_od_low(mp_hal_pin_obj_t pin) {


### PR DESCRIPTION
Per https://github.com/micropython/micropython-esp32/issues/189