### PR TITLE
esp32/esp: read internal temperature sensor

### DIFF
--- a/ports/esp32/modesp.c
+++ b/ports/esp32/modesp.c
@@ -104,6 +104,11 @@ STATIC mp_obj_t esp_neopixel_write_(mp_obj_t pin, mp_obj_t buf, mp_obj_t timing)
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(esp_neopixel_write_obj, esp_neopixel_write_);
 
+STATIC mp_obj_t esp_temperature_read(void) {
+    return mp_obj_new_int_from_uint(temprature_sens_read());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(esp_temperature_read_obj, esp_temperature_read);
+
 STATIC const mp_rom_map_elem_t esp_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_esp) },
 
@@ -118,6 +123,7 @@ STATIC const mp_rom_map_elem_t esp_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_neopixel_write), MP_ROM_PTR(&esp_neopixel_write_obj) },
     { MP_ROM_QSTR(MP_QSTR_dht_readinto), MP_ROM_PTR(&dht_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_temperature_read), MP_ROM_PTR(&esp_temperature_read_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(esp_module_globals, esp_module_globals_table);

--- a/ports/esp32/modesp.h
+++ b/ports/esp32/modesp.h
@@ -1,1 +1,9 @@
+#ifndef MICROPY_INCLUDED_ESP32_MODESP_H
+#define MICROPY_INCLUDED_ESP32_MODESP_H
+
+#include <stdint.h>
+
 void esp_neopixel_write(uint8_t pin, uint8_t *pixels, uint32_t numBytes, uint8_t timing);
+uint8_t temprature_sens_read(void);
+
+#endif // MICROPY_INCLUDED_ESP32_MODESP_H


### PR DESCRIPTION
Add a function to the `esp` module to read the ESP32's internal temperature sensor. This uses `temprature_sens_read()`[1] from the `librtc.a` library linked from the ESP-IDF.

I stuffed this into the `esp` module because it doesn't seem significant enough to warrant a new class in the `machine` module. Additionally, it could be seen as a property of the ESP32 module, like flash size.

This pull request is primarily a means for me to learn how micropython interacts with the ESP-IDF. Let me know if anything has not been implemented properly.

[1] misspelling is present in the ESP-IDF