### PR TITLE
Esp32 WLAN.config protocol (including LR)

### DIFF
--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -403,7 +403,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         break;
                     }
                     case QS(MP_QSTR_protocol): {
-			esp_wifi_set_protocol(self->if_id, mp_obj_get_int(kwargs->table[i].value));
+			ESP_EXCEPTIONS(esp_wifi_set_protocol(self->if_id, mp_obj_get_int(kwargs->table[i].value)));
 			break;
 		    }
                     case QS(MP_QSTR_essid): {
@@ -471,6 +471,11 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
             uint8_t mac[6];
             ESP_EXCEPTIONS(esp_wifi_get_mac(self->if_id, mac));
             return mp_obj_new_bytes(mac, sizeof(mac));
+        }
+	case QS(MP_QSTR_protocol): {
+            uint8_t protocol_bitmap;
+            ESP_EXCEPTIONS(esp_wifi_get_protocol(self->if_id, &protocol_bitmap));
+            return mp_obj_new_int(protocol_bitmap);
         }
         case QS(MP_QSTR_essid):
             req_if = WIFI_IF_AP;

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -402,6 +402,10 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         ESP_EXCEPTIONS(esp_wifi_set_mac(self->if_id, bufinfo.buf));
                         break;
                     }
+                    case QS(MP_QSTR_protocol): {
+			esp_wifi_set_protocol(self->if_id, mp_obj_get_int(kwargs->table[i].value));
+			break;
+		    }
                     case QS(MP_QSTR_essid): {
                         req_if = WIFI_IF_AP;
                         mp_uint_t len;
@@ -545,6 +549,8 @@ STATIC const mp_map_elem_t mp_module_network_globals_table[] = {
         MP_OBJ_NEW_SMALL_INT(WIFI_PROTOCOL_11G) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_MODE_11N),
         MP_OBJ_NEW_SMALL_INT(WIFI_PROTOCOL_11N) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_MODE_LR),
+        MP_OBJ_NEW_SMALL_INT(WIFI_PROTOCOL_LR) },
 
     { MP_OBJ_NEW_QSTR(MP_QSTR_AUTH_OPEN),
         MP_OBJ_NEW_SMALL_INT(WIFI_AUTH_OPEN) },


### PR DESCRIPTION
Adds support for selecting WiFi protocol for a WLAN interface using the WLAN().config() method.

Includes support for "802.11 LR", an Espressif-specific Low Rate / Long Range version of 802.11.
See https://dl.espressif.com/doc/esp-idf/latest/api-guides/wifi.html#wi-fi-protocol-mode

