### PR TITLE
ESP-Now

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -139,6 +139,7 @@ SRC_C = \
 	network_lan.c \
 	modsocket.c \
 	modesp.c \
+	esp_espnow.c \
 	moduhashlib.c \
 	espneopixel.c \
 	machine_hw_spi.c \
@@ -623,7 +624,7 @@ APP_LD_ARGS += -L$(dir $(LIBSTDCXX_FILE_NAME)) -lstdc++
 APP_LD_ARGS += $(ESPCOMP)/newlib/lib/libc.a
 APP_LD_ARGS += $(ESPCOMP)/newlib/lib/libm.a
 APP_LD_ARGS += $(ESPCOMP)/esp32/libhal.a
-APP_LD_ARGS += -L$(ESPCOMP)/esp32/lib -lcore -lnet80211 -lphy -lrtc -lpp -lwpa -lsmartconfig -lcoexist -lwps -lwpa2
+APP_LD_ARGS += -L$(ESPCOMP)/esp32/lib -lcore -lnet80211 -lphy -lrtc -lpp -lwpa -lsmartconfig -lcoexist -lwps -lwpa2 -lespnow
 APP_LD_ARGS += $(OBJ)
 APP_LD_ARGS += --end-group
 

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -29,7 +29,7 @@ ESPCOMP = $(ESPIDF)/components
 ESPTOOL ?= $(ESPCOMP)/esptool_py/esptool/esptool.py
 
 # verify the ESP IDF version
-ESPIDF_SUPHASH := e6afe28bafe5db5ab79fae213f2e8e1ccd9f937c
+ESPIDF_SUPHASH := 2c95a77cf93781f296883d5dbafcdc18e4389656
 ESPIDF_CURHASH := $(shell git -C $(ESPIDF) show -s --pretty=format:'%H')
 ifneq ($(ESPIDF_CURHASH),$(ESPIDF_SUPHASH))
 $(info ** WARNING **)

--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -29,7 +29,7 @@ ESPCOMP = $(ESPIDF)/components
 ESPTOOL ?= $(ESPCOMP)/esptool_py/esptool/esptool.py
 
 # verify the ESP IDF version
-ESPIDF_SUPHASH := 2c95a77cf93781f296883d5dbafcdc18e4389656
+ESPIDF_SUPHASH := e6afe28bafe5db5ab79fae213f2e8e1ccd9f937c
 ESPIDF_CURHASH := $(shell git -C $(ESPIDF) show -s --pretty=format:'%H')
 ifneq ($(ESPIDF_CURHASH),$(ESPIDF_SUPHASH))
 $(info ** WARNING **)

--- a/ports/esp32/esp_espnow.c
+++ b/ports/esp32/esp_espnow.c
@@ -1,0 +1,182 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Nick Moore
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "esp_log.h"
+#include "esp_now.h"
+#include "esp_wifi.h"
+
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "py/nlr.h"
+#include "py/objlist.h"
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "py/mperrno.h"
+
+#include "modnetwork.h"
+
+NORETURN void _esp_espnow_exceptions(esp_err_t e) {
+   switch (e) {
+      case ESP_ERR_ESPNOW_NOT_INIT:
+        mp_raise_msg(&mp_type_OSError, "ESP-Now Not Initialized");
+      case ESP_ERR_ESPNOW_ARG:
+        mp_raise_msg(&mp_type_OSError, "ESP-Now Invalid Argument");
+      case ESP_ERR_ESPNOW_NO_MEM:
+        mp_raise_msg(&mp_type_OSError, "ESP-Now Out Of Mem");
+      case ESP_ERR_ESPNOW_FULL:
+        mp_raise_msg(&mp_type_OSError, "ESP-Now Peer List Full");
+      case ESP_ERR_ESPNOW_NOT_FOUND:
+        mp_raise_msg(&mp_type_OSError, "ESP-Now Peer Not Found");
+      case ESP_ERR_ESPNOW_INTERNAL:
+        mp_raise_msg(&mp_type_OSError, "ESP-Now Internal");
+      case ESP_ERR_ESPNOW_EXIST:
+        mp_raise_msg(&mp_type_OSError, "ESP-Now Peer Exists");
+      default:
+        nlr_raise(mp_obj_new_exception_msg_varg(
+          &mp_type_RuntimeError, "ESP-Now Unknown Error 0x%04x", e
+        ));
+   }
+}
+
+static inline void esp_espnow_exceptions(esp_err_t e) {
+    if (e != ESP_OK) _esp_espnow_exceptions(e);
+}
+
+static inline void _get_bytes(mp_obj_t str, size_t len, uint8_t *dst) {
+    size_t str_len;
+    const char *data = mp_obj_str_get_data(str, &str_len);	
+    if (str_len != len) mp_raise_ValueError("bad len");
+    memcpy(dst, data, len);
+}
+
+// this is crap of course but lets try it
+
+static int recv_buf_len = 0;
+uint8_t recv_mac[6];
+static uint8_t recv_buffer[250];
+
+STATIC mp_obj_t espnow_recv() {
+    if (recv_buf_len < 1) return mp_const_none;
+    mp_obj_tuple_t *msg = mp_obj_new_tuple(2, NULL);
+    msg->items[0] = mp_obj_new_bytes(recv_mac, sizeof(recv_mac));
+    msg->items[1] = mp_obj_new_bytes(recv_buffer, recv_buf_len);
+    recv_buf_len = 0;
+    return msg;
+}
+
+MP_DEFINE_CONST_FUN_OBJ_0(espnow_recv_obj, espnow_recv);
+
+void simple_cb(const uint8_t *macaddr, const uint8_t *data, int len) 
+{
+    if (len < sizeof(recv_buffer)) {
+        memcpy(recv_buffer, data, len);
+	memcpy(recv_mac, macaddr, 6);
+	recv_buf_len = len;
+    }
+} 
+
+static int initialized = 0;
+
+STATIC mp_obj_t espnow_init() {
+    if (!initialized) {
+        esp_now_init();
+        initialized = 1;
+	esp_now_register_recv_cb(simple_cb);
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_0(espnow_init_obj, espnow_init);
+
+STATIC mp_obj_t espnow_deinit() {
+    if (initialized) {
+        esp_now_deinit();
+        initialized = 0;
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_0(espnow_deinit_obj, espnow_deinit);
+
+STATIC mp_obj_t espnow_set_pmk(mp_obj_t pmk) {
+    uint8_t buf[ESP_NOW_ETH_ALEN];
+    _get_bytes(pmk, ESP_NOW_ETH_ALEN, buf);
+    esp_espnow_exceptions(esp_now_set_pmk(buf));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(espnow_set_pmk_obj, espnow_set_pmk);
+
+STATIC mp_obj_t espnow_add_peer(size_t n_args, const mp_obj_t *args) {
+    esp_now_peer_info_t peer = {0};
+    peer.ifidx = ((wlan_if_obj_t *)MP_OBJ_TO_PTR(args[0]))->if_id;
+    _get_bytes(args[1], ESP_NOW_ETH_ALEN, peer.peer_addr);
+    _get_bytes(args[2], ESP_NOW_KEY_LEN, peer.lmk);
+    peer.encrypt = (n_args > 3 && mp_obj_is_true(args[3])) ? 1 : 0;
+    // leaving channel as 0 for autodetect
+    esp_espnow_exceptions(esp_now_add_peer(&peer));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(espnow_add_peer_obj, 3, 4, espnow_add_peer);
+
+STATIC mp_obj_t espnow_send(mp_obj_t addr, mp_obj_t msg) {
+    mp_uint_t len1;
+    const uint8_t *buf1 = (const uint8_t *)mp_obj_str_get_data(addr, &len1);
+    mp_uint_t len2;
+    const uint8_t *buf2 = (const uint8_t *)mp_obj_str_get_data(msg, &len2);
+    if (len1 != ESP_NOW_ETH_ALEN) mp_raise_ValueError("addr invalid");
+    if (len2 > ESP_NOW_MAX_DATA_LEN) mp_raise_ValueError("Msg too long");
+    esp_espnow_exceptions(esp_now_send(buf1, buf2, len2));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(espnow_send_obj, espnow_send);
+
+STATIC mp_obj_t espnow_send_all(mp_obj_t msg) {
+    mp_uint_t len;
+    const uint8_t *buf = (const uint8_t *)mp_obj_str_get_data(msg, &len);
+    if (len > ESP_NOW_MAX_DATA_LEN) mp_raise_ValueError("Msg too long");
+    esp_espnow_exceptions(esp_now_send(NULL, buf, len));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(espnow_send_all_obj, espnow_send_all);
+
+STATIC const mp_rom_map_elem_t espnow_globals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&espnow_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&espnow_deinit_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_pmk), MP_ROM_PTR(&espnow_set_pmk_obj) },
+    { MP_ROM_QSTR(MP_QSTR_add_peer), MP_ROM_PTR(&espnow_add_peer_obj) },
+    { MP_ROM_QSTR(MP_QSTR_send), MP_ROM_PTR(&espnow_send_obj) },
+    { MP_ROM_QSTR(MP_QSTR_send_all), MP_ROM_PTR(&espnow_send_all_obj) },
+    { MP_ROM_QSTR(MP_QSTR_recv), MP_ROM_PTR(&espnow_recv_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(espnow_globals_dict, espnow_globals_dict_table);
+
+const mp_obj_module_t mp_module_esp_espnow = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&espnow_globals_dict,
+};

--- a/ports/esp32/modesp.c
+++ b/ports/esp32/modesp.c
@@ -104,6 +104,8 @@ STATIC mp_obj_t esp_neopixel_write_(mp_obj_t pin, mp_obj_t buf, mp_obj_t timing)
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(esp_neopixel_write_obj, esp_neopixel_write_);
 
+extern const mp_obj_module_t mp_module_esp_espnow;
+
 STATIC const mp_rom_map_elem_t esp_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_esp) },
 
@@ -118,6 +120,7 @@ STATIC const mp_rom_map_elem_t esp_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_neopixel_write), MP_ROM_PTR(&esp_neopixel_write_obj) },
     { MP_ROM_QSTR(MP_QSTR_dht_readinto), MP_ROM_PTR(&dht_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_espnow), MP_ROM_PTR(&mp_module_esp_espnow) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(esp_module_globals, esp_module_globals_table);

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -412,6 +412,10 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         ESP_EXCEPTIONS(esp_wifi_set_mac(self->if_id, bufinfo.buf));
                         break;
                     }
+                    case QS(MP_QSTR_protocol): {
+			esp_wifi_set_protocol(self->if_id, mp_obj_get_int(kwargs->table[i].value));
+			break;
+		    }
                     case QS(MP_QSTR_essid): {
                         req_if = WIFI_IF_AP;
                         mp_uint_t len;
@@ -556,6 +560,8 @@ STATIC const mp_map_elem_t mp_module_network_globals_table[] = {
         MP_OBJ_NEW_SMALL_INT(WIFI_PROTOCOL_11G) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_MODE_11N),
         MP_OBJ_NEW_SMALL_INT(WIFI_PROTOCOL_11N) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_MODE_LR),
+        MP_OBJ_NEW_SMALL_INT(WIFI_PROTOCOL_LR) },
 
     { MP_OBJ_NEW_QSTR(MP_QSTR_AUTH_OPEN),
         MP_OBJ_NEW_SMALL_INT(WIFI_AUTH_OPEN) },

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -361,18 +361,11 @@ STATIC mp_obj_t esp_ifconfig(size_t n_args, const mp_obj_t *args) {
         netutils_parse_ipv4_addr(items[2], (void*)&info.gw, NETUTILS_BIG);
         netutils_parse_ipv4_addr(items[3], (void*)&dns_info.ip, NETUTILS_BIG);
         // To set a static IP we have to disable DHCP first
-<<<<<<< HEAD
-        if (self->if_id == WIFI_IF_STA || self->if_id == ESP_IF_ETH) {
-            esp_err_t e = tcpip_adapter_dhcpc_stop(self->if_id);
-            if (e != ESP_OK && e != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED) _esp_exceptions(e);
-            ESP_EXCEPTIONS(tcpip_adapter_set_ip_info(self->if_id, &info));
-            ESP_EXCEPTIONS(tcpip_adapter_set_dns_info(self->if_id, TCPIP_ADAPTER_DNS_MAIN, &dns_info));
-=======
         if (self->if_id == WIFI_IF_STA) {
             esp_err_t e = tcpip_adapter_dhcpc_stop(WIFI_IF_STA);
             if (e != ESP_OK && e != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED) _esp_network_exceptions(e);
             ESP_EXCEPTIONS(tcpip_adapter_set_ip_info(WIFI_IF_STA, &info));
->>>>>>> ... start on espnow
+            ESP_EXCEPTIONS(tcpip_adapter_set_dns_info(self->if_id, TCPIP_ADAPTER_DNS_MAIN, &dns_info));
         } else if (self->if_id == WIFI_IF_AP) {
             esp_err_t e = tcpip_adapter_dhcps_stop(WIFI_IF_AP);
             if (e != ESP_OK && e != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED) _esp_network_exceptions(e);

--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -53,7 +53,7 @@
 
 #define MODNETWORK_INCLUDE_CONSTANTS (1)
 
-NORETURN void _esp_exceptions(esp_err_t e) {
+NORETURN void _esp_network_exceptions(esp_err_t e) {
    switch (e) {
       case ESP_ERR_WIFI_NOT_INIT: 
         mp_raise_msg(&mp_type_OSError, "Wifi Not Initialized");
@@ -95,16 +95,11 @@ NORETURN void _esp_exceptions(esp_err_t e) {
    }
 }
 
-static inline void esp_exceptions(esp_err_t e) {
-    if (e != ESP_OK) _esp_exceptions(e);
+static inline void esp_network_exceptions(esp_err_t e) {
+    if (e != ESP_OK) _esp_network_exceptions(e);
 }
 
-#define ESP_EXCEPTIONS(x) do { esp_exceptions(x); } while (0);
-
-typedef struct _wlan_if_obj_t {
-    mp_obj_base_t base;
-    int if_id;
-} wlan_if_obj_t;
+#define ESP_EXCEPTIONS(x) do { esp_network_exceptions(x); } while (0);
 
 const mp_obj_type_t wlan_if_type;
 STATIC const wlan_if_obj_t wlan_sta_obj = {{&wlan_if_type}, WIFI_IF_STA};
@@ -366,14 +361,21 @@ STATIC mp_obj_t esp_ifconfig(size_t n_args, const mp_obj_t *args) {
         netutils_parse_ipv4_addr(items[2], (void*)&info.gw, NETUTILS_BIG);
         netutils_parse_ipv4_addr(items[3], (void*)&dns_info.ip, NETUTILS_BIG);
         // To set a static IP we have to disable DHCP first
+<<<<<<< HEAD
         if (self->if_id == WIFI_IF_STA || self->if_id == ESP_IF_ETH) {
             esp_err_t e = tcpip_adapter_dhcpc_stop(self->if_id);
             if (e != ESP_OK && e != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED) _esp_exceptions(e);
             ESP_EXCEPTIONS(tcpip_adapter_set_ip_info(self->if_id, &info));
             ESP_EXCEPTIONS(tcpip_adapter_set_dns_info(self->if_id, TCPIP_ADAPTER_DNS_MAIN, &dns_info));
+=======
+        if (self->if_id == WIFI_IF_STA) {
+            esp_err_t e = tcpip_adapter_dhcpc_stop(WIFI_IF_STA);
+            if (e != ESP_OK && e != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED) _esp_network_exceptions(e);
+            ESP_EXCEPTIONS(tcpip_adapter_set_ip_info(WIFI_IF_STA, &info));
+>>>>>>> ... start on espnow
         } else if (self->if_id == WIFI_IF_AP) {
             esp_err_t e = tcpip_adapter_dhcps_stop(WIFI_IF_AP);
-            if (e != ESP_OK && e != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED) _esp_exceptions(e);
+            if (e != ESP_OK && e != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED) _esp_network_exceptions(e);
             ESP_EXCEPTIONS(tcpip_adapter_set_ip_info(WIFI_IF_AP, &info));
             ESP_EXCEPTIONS(tcpip_adapter_set_dns_info(WIFI_IF_AP, TCPIP_ADAPTER_DNS_MAIN, &dns_info));
             ESP_EXCEPTIONS(tcpip_adapter_dhcps_start(WIFI_IF_AP));

--- a/ports/esp32/modnetwork.h
+++ b/ports/esp32/modnetwork.h
@@ -31,4 +31,9 @@ enum { PHY_LAN8720, PHY_TLK110 };
 MP_DECLARE_CONST_FUN_OBJ_KW(get_lan_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(esp_ifconfig_obj);
 
-#endif
+typedef struct _wlan_if_obj_t {
+    mp_obj_base_t base;
+    int if_id;
+} wlan_if_obj_t;
+
+#endif // MICROPY_INCLUDED_ESP32_MODESP_MODNETWORK_H


### PR DESCRIPTION
Support for the ESP-Now protocol, as per #197 

Sample code:
```
import network
import esp
w = network.WLAN()
w.active(True)
esp.espnow.init()
bcast = bytes([255,255,255,255,255,255])
esp.espnow.add_peer(w, bcast)
esp.espnow.set_recv_cb(lambda x: print("RECV %s %s" % x))
esp.espnow.set_send_cb(lambda x: print("SEND %s %s" % x))
esp.espnow.send(bcast, "hello, world")
```
The API could probably still use some work, but this is a first stab at it.