### PR TITLE
time.ticks_ms() as uint32_t and time.ticks_us() as uint64_t based on esp_timer_impl_get_time()

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -56,6 +56,7 @@ INC_ESPCOMP += -I$(ESPCOMP)/driver/include/driver
 INC_ESPCOMP += -I$(ESPCOMP)/nghttp/port/include
 INC_ESPCOMP += -I$(ESPCOMP)/nghttp/nghttp2/lib/includes
 INC_ESPCOMP += -I$(ESPCOMP)/esp32/include
+INC_ESPCOMP += -I$(ESPCOMP)/esp32/
 INC_ESPCOMP += -I$(ESPCOMP)/soc/include
 INC_ESPCOMP += -I$(ESPCOMP)/soc/esp32/include
 INC_ESPCOMP += -I$(ESPCOMP)/ethernet/include

--- a/ports/esp32/modutime.c
+++ b/ports/esp32/modutime.c
@@ -33,6 +33,8 @@
 #include "py/runtime.h"
 #include "lib/timeutils/timeutils.h"
 #include "extmod/utime_mphal.h"
+#include "esp_timer_impl.h"
+
 
 STATIC mp_obj_t time_localtime(size_t n_args, const mp_obj_t *args) {
     timeutils_struct_time_t tm;
@@ -82,6 +84,20 @@ STATIC mp_obj_t time_time(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(time_time_obj, time_time);
 
+STATIC mp_obj_t time_ticks_ms(void) {
+    uint64_t us = esp_timer_impl_get_time();
+    uint32_t ms = (uint32_t)(us / 1000);
+    return MP_OBJ_NEW_SMALL_INT(ms);
+}
+MP_DEFINE_CONST_FUN_OBJ_0(mp_utime_esp32_ticks_ms_obj, time_ticks_ms);
+
+STATIC mp_obj_t time_ticks_us(void) {
+    uint64_t us = esp_timer_impl_get_time();
+    return mp_obj_new_int_from_ull(us);
+}
+MP_DEFINE_CONST_FUN_OBJ_0(mp_utime_esp32_ticks_us_obj, time_ticks_us);
+
+
 STATIC const mp_rom_map_elem_t time_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_utime) },
 
@@ -91,8 +107,8 @@ STATIC const mp_rom_map_elem_t time_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_sleep), MP_ROM_PTR(&mp_utime_sleep_obj) },
     { MP_ROM_QSTR(MP_QSTR_sleep_ms), MP_ROM_PTR(&mp_utime_sleep_ms_obj) },
     { MP_ROM_QSTR(MP_QSTR_sleep_us), MP_ROM_PTR(&mp_utime_sleep_us_obj) },
-    { MP_ROM_QSTR(MP_QSTR_ticks_ms), MP_ROM_PTR(&mp_utime_ticks_ms_obj) },
-    { MP_ROM_QSTR(MP_QSTR_ticks_us), MP_ROM_PTR(&mp_utime_ticks_us_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ticks_ms), MP_ROM_PTR(&mp_utime_esp32_ticks_ms_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ticks_us), MP_ROM_PTR(&mp_utime_esp32_ticks_us_obj) },
     { MP_ROM_QSTR(MP_QSTR_ticks_cpu), MP_ROM_PTR(&mp_utime_ticks_cpu_obj) },
     { MP_ROM_QSTR(MP_QSTR_ticks_add), MP_ROM_PTR(&mp_utime_ticks_add_obj) },
     { MP_ROM_QSTR(MP_QSTR_ticks_diff), MP_ROM_PTR(&mp_utime_ticks_diff_obj) },


### PR DESCRIPTION
Herby I propose to implement the **time.ticks_us()** as a full uint64_t without any masking
and **time.ticks_ms()** as full uint32_t without any masking.

The implementation is based on **esp_timer_impl_get_time()**, a 64 bit microsecond counter.
uint64_t with microseconds will overflow in 2^64 / (1e6 * 60 * 60 * 24 * 365) = 292471,21 year
uint32_t with milliseconds will overflow in 2^32 / (1e3 * 60 * 60 * 24) = 49,71 days

With this implementation there is no need anymore to calculate time diffs with ticks_diff.
And far less cpu cycles is spend in calculating the ticks, and ticks diffs

The original implementation is based on gettimeofday. If one sets the timeofday to the correct value, the resulting value of function time.ticks_us() and time.ticks_ms() make a jump to a value beyond the 32 bits value, leaving the 32 bits remainder as resulting value.

This is very unhandy, as it is very difficult to cope with the jump in the absolute value in ticks,
if one uses an OS (asyncio) based on ticks_ms. Starting the OS can only be done after setting the timeofday, and while running it is not possible to adjust the timeof day, due to the possible ticks jump.

Testing of the microseconds timer can be done with next code:

```
import utime as time

def showtime(us):
	useconds = us % 1000000
	tseconds  = us // 1000000

	tminutes = tseconds // 60
	seconds  = tseconds % 60

	thours   = tminutes // 60
	minutes  = tminutes % 60

	tdays    = thours // 24
	hours    = thours % 24

	tyears   = tdays // 365
	days     = tdays %  365

	print ("years:%s  days:%s  h:%2s  m:%2s  s:%2s  us:%s  raw:%s"%(tyears, days,hours,minutes,seconds,useconds,us) )

while (True):
	us = time.ticks_us()
	showtime(us)
	time.sleep(10)

```