### PR TITLE
Fix for issue 235 -- MicroPython images larger than 1MiB

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -717,7 +717,7 @@ $(BUILD)/bootloader.elf: $(BOOTLOADER_OBJ)
 # Declarations to build the partitions
 
 PYTHON2 ?= python2
-PART_SRC = $(ESPCOMP)/partition_table/partitions_singleapp.csv
+PART_SRC = partitions.csv
 
 $(BUILD)/partitions.bin: $(PART_SRC)
 	$(ECHO) "Create $@"

--- a/ports/esp32/partitions.csv
+++ b/ports/esp32/partitions.csv
@@ -1,0 +1,5 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+# Note: if you change the phy_init or app partition offset, make sure to change the offset in Kconfig.projbuild
+nvs,      data, nvs,     0x9000,  0x6000,
+phy_init, data, phy,     0xf000,  0x1000,
+factory,  app,  factory, 0x10000, 0x180000,


### PR DESCRIPTION
ports/esp32/partitions.csv: Custom partition file
ports/esp32/Makefile: Updated to use new partition file

https://github.com/micropython/micropython-esp32/issues/235